### PR TITLE
DOCS-3011 re AM runtimes and basic metric support

### DIFF
--- a/modules/ROOT/pages/dashboard-config-ref.adoc
+++ b/modules/ROOT/pages/dashboard-config-ref.adoc
@@ -32,72 +32,72 @@ Many <<metrics_basic, basic>> and <<metrics_advanced, advanced>> metrics are ava
 
 These metrics are available when you use the Basic mode:
 
-[%header,cols="3,1"]
+[%header,cols="3,1,1"]
 |===
-| Basic Metrics | Unit
-| Inbound - Average Request Count by Endpoint | `short`
-| Inbound - Average Request Count by Flow | `short`
-| Inbound - Average Response Count by Endpoint | `short`
-| Inbound - Average Response Count by Flow | `short`
-| Inbound - Failure Average Request Count by Endpoint  | `short`
-| Inbound - Failure Average Request Count by Flow | `short`
-| Inbound - Failure Average Response Time by Endpoint | `ms`
-| Inbound - Failure Average Response Time by Flow | `ms`
-| Inbound - Success Average Request Count by Endpoint  | `short`
-| Inbound - Success Average Request Count by Flow | `short`
-| Inbound - Success Average Response Time by Endpoint | `ms`
-| Inbound - Success Average Response Time by Flow | `ms`
-| JVM - CPU % Utilization | `percent`
-| JVM - CPU Load Average | `percent`
-| JVM - Classes Loaded | `short`
-| JVM - Classes Loaded Total | `short`
-| JVM - Classes Unloaded | `short`
-| JVM - Code Cache Committed | `bytes`
-| JVM - Code Cache Init | `bytes`
-| JVM - Code Cache Max | `bytes`
-| JVM - Code Cache Used | `bytes`
-| JVM - Compressed Class Space Committed | `bytes`
-| JVM - Compressed Class Space Total | `bytes`
-| JVM - Compressed Class Space Used | `bytes`
-| JVM - Garbage Collection Count | `short`
-| JVM - Garbage Collection Time | `ms`
-| JVM - Heap Committed | `bytes`
-| JVM - Heap Used | `bytes`
-| JVM - JVM Uptime | `ms`
-| JVM - Memory Utilization | `bytes`
-| JVM - Metaspace Committed | `bytes`
-| JVM - Metaspace Init | `bytes`
-| JVM - Metaspace Max | `bytes`
-| JVM - Metaspace Used | `bytes`
-| JVM - Par Eden Committed | `bytes`
-| JVM - Par Eden Init | `bytes`
-| JVM - Par Eden Max | `bytes`
-| JVM - Par Eden Used | `bytes`
-| JVM - Par New Collection Count | `short`
-| JVM - Par New Collection Time | `ms`
-| JVM - Par Survivor Committed | `bytes`
-| JVM - Par Survivor Init | `bytes`
-| JVM - Par Survivor Max | `bytes`
-| JVM - Par Survivor Used | `bytes`
-| JVM - Tenured Gen Committed | `bytes`
-| JVM - Tenured Gen Init | `bytes`
-| JVM - Tenured Gen Max | `bytes`
-| JVM - Tenured Gen Used | `bytes`
-| JVM - Thread count - Server | `short`
-| JVM - Total System Memory | `bytes`
-| JVM - Total System Processors | `short`
-| Outbound - Average Request Count by Endpoint | `short`
-| Outbound - Average Request Count by Flow | `short`
-| Outbound - Average Response Time by Endpoint | `ms`
-| Outbound - Average Response Time by Flow | `ms`
-| Outbound - Failure Average Request Count by Endpoint | `short`
-| Outbound - Failure Average Request Count by Flow | `short`
-| Outbound - Failure Average Response Time by Endpoint | `ms`
-| Outbound - Failure Average Response Time by Flow | `ms`
-| Outbound - Success Average Request Count by Endpoint | `short`
-| Outbound - Success Average Request Count by Flow | `short`
-| Outbound - Success Average Response Time by Endpoint | `ms`
-| Outbound - Success Average Response Time by Flow | `ms`
+| Basic Metrics | Unit | Runtime Version Support
+| Inbound - Average Request Count by Endpoint | `short` | 3.x-AM only
+| Inbound - Average Request Count by Flow | `short` | 3.x-AM only
+| Inbound - Average Response Count by Endpoint | `short` | 3.x-AM only
+| Inbound - Average Response Count by Flow | `short` | 3.x-AM only
+| Inbound - Failure Average Request Count by Endpoint  | `short` | 3.x-AM only
+| Inbound - Failure Average Request Count by Flow | `short` | 3.x-AM only
+| Inbound - Failure Average Response Time by Endpoint | `ms` | 3.x-AM only
+| Inbound - Failure Average Response Time by Flow | `ms` | 3.x-AM only
+| Inbound - Success Average Request Count by Endpoint  | `short` | 3.x-AM only
+| Inbound - Success Average Request Count by Flow | `short` | 3.x-AM only
+| Inbound - Success Average Response Time by Endpoint | `ms` | 3.x-AM only
+| Inbound - Success Average Response Time by Flow | `ms` | 3.x-AM only
+| JVM - CPU % Utilization | `percent` | 3.x-AM, 4.x-AM
+| JVM - CPU Load Average | `percent` | 3.x-AM, 4.x-AM
+| JVM - Classes Loaded | `short` | 3.x-AM, 4.x-AM
+| JVM - Classes Loaded Total | `short` | 3.x-AM, 4.x-AM
+| JVM - Classes Unloaded | `short` | 3.x-AM, 4.x-AM
+| JVM - Code Cache Committed | `bytes` | 3.x-AM, 4.x-AM
+| JVM - Code Cache Init | `bytes` | 3.x-AM, 4.x-AM
+| JVM - Code Cache Max | `bytes` | 3.x-AM, 4.x-AM
+| JVM - Code Cache Used | `bytes` | 3.x-AM, 4.x-AM
+| JVM - Compressed Class Space Committed | `bytes` | 3.x-AM, 4.x-AM
+| JVM - Compressed Class Space Total | `bytes` | 3.x-AM, 4.x-AM
+| JVM - Compressed Class Space Used | `bytes` | 3.x-AM, 4.x-AM
+| JVM - Garbage Collection Count | `short` | 3.x-AM, 4.x-AM
+| JVM - Garbage Collection Time | `ms` | 3.x-AM, 4.x-AM
+| JVM - Heap Committed | `bytes` | 3.x-AM, 4.x-AM
+| JVM - Heap Used | `bytes` | 3.x-AM, 4.x-AM
+| JVM - JVM Uptime | `ms` | 3.x-AM, 4.x-AM
+| JVM - Memory Utilization | `bytes` | 3.x-AM, 4.x-AM
+| JVM - Metaspace Committed | `bytes` | 3.x-AM, 4.x-AM
+| JVM - Metaspace Init | `bytes` | 3.x-AM, 4.x-AM
+| JVM - Metaspace Max | `bytes` | 3.x-AM, 4.x-AM
+| JVM - Metaspace Used | `bytes` | 3.x-AM, 4.x-AM
+| JVM - Par Eden Committed | `bytes` | 3.x-AM, 4.x-AM
+| JVM - Par Eden Init | `bytes` | 3.x-AM, 4.x-AM
+| JVM - Par Eden Max | `bytes` | 3.x-AM, 4.x-AM
+| JVM - Par Eden Used | `bytes` | 3.x-AM, 4.x-AM
+| JVM - Par New Collection Count | `short` | 3.x-AM, 4.x-AM
+| JVM - Par New Collection Time | `ms` | 3.x-AM, 4.x-AM
+| JVM - Par Survivor Committed | `bytes` | 3.x-AM, 4.x-AM
+| JVM - Par Survivor Init | `bytes` | 3.x-AM, 4.x-AM
+| JVM - Par Survivor Max | `bytes` | 3.x-AM, 4.x-AM
+| JVM - Par Survivor Used | `bytes` | 3.x-AM, 4.x-AM
+| JVM - Tenured Gen Committed | `bytes` | 3.x-AM, 4.x-AM
+| JVM - Tenured Gen Init | `bytes` | 3.x-AM, 4.x-AM
+| JVM - Tenured Gen Max | `bytes` | 3.x-AM, 4.x-AM
+| JVM - Tenured Gen Used | `bytes` | 3.x-AM, 4.x-AM
+| JVM - Thread count - Server | `short` | 3.x-AM, 4.x-AM
+| JVM - Total System Memory | `bytes` | 3.x-AM, 4.x-AM
+| JVM - Total System Processors | `short` | 3.x-AM, 4.x-AM
+| Outbound - Average Request Count by Endpoint | `short` | 3.x-AM only
+| Outbound - Average Request Count by Flow | `short` | 3.x-AM only
+| Outbound - Average Response Time by Endpoint | `ms` | 3.x-AM only
+| Outbound - Average Response Time by Flow | `ms` | 3.x-AM only
+| Outbound - Failure Average Request Count by Endpoint | `short` | 3.x-AM only
+| Outbound - Failure Average Request Count by Flow | `short` | 3.x-AM only
+| Outbound - Failure Average Response Time by Endpoint | `ms` | 3.x-AM only
+| Outbound - Failure Average Response Time by Flow | `ms` | 3.x-AM only
+| Outbound - Success Average Request Count by Endpoint | `short` | 3.x-AM only
+| Outbound - Success Average Request Count by Flow | `short` | 3.x-AM only
+| Outbound - Success Average Response Time by Endpoint | `ms` | 3.x-AM only
+| Outbound - Success Average Response Time by Flow | `ms` | 3.x-AM only
 |===
 
 [[metrics_advanced]]

--- a/modules/ROOT/pages/quick-start.adoc
+++ b/modules/ROOT/pages/quick-start.adoc
@@ -51,9 +51,9 @@ Typically, administrators set permissions through Access Management. See xref:ac
 For Anypoint Monitoring to start monitoring your Mule apps, you must deploy them
 to the appropriate version of Mule runtime.  Note that the Anypoint Monitoring
 images (for example, 3.9.1-AM) receive the latest patch updates once per month,
-while the non-AM (mainline) images receive patch updates as soon as they are
-available. If you require the latest patch releases, you should use the non-AM
-images.
+while the non-AM (standard) images receive patch updates as soon as they are
+available. If your production environment requires a Mule runtime patch, MuleSoft
+recommends that you switch to a standard runtime, without Anypoint Monitoring support.
 
 |===
 | Platform | Mule Version | Features

--- a/modules/ROOT/pages/quick-start.adoc
+++ b/modules/ROOT/pages/quick-start.adoc
@@ -51,9 +51,9 @@ Typically, administrators set permissions through Access Management. See xref:ac
 For Anypoint Monitoring to start monitoring your Mule apps, you must deploy them
 to the appropriate version of Mule runtime.  Note that the Anypoint Monitoring
 images (for example, 3.9.1-AM) receive the latest patch updates once per month,
-while the non-AM (standard) images receive patch updates as soon as they are
+while the non-AM (mainline) images receive patch updates as soon as they are
 available. If your production environment requires a Mule runtime patch, MuleSoft
-recommends that you switch to a standard runtime, without Anypoint Monitoring support.
+recommends that you switch to a mainline runtime.
 
 |===
 | Platform | Mule Version | Features

--- a/modules/ROOT/pages/quick-start.adoc
+++ b/modules/ROOT/pages/quick-start.adoc
@@ -48,7 +48,12 @@ Typically, administrators set permissions through Access Management. See xref:ac
 [[runtime_versions]]
 == Supported Platform and Mule Versions
 
-For Anypoint Monitoring to start monitoring your Mule apps, you must deploy them to the appropriate version of Mule runtime.
+For Anypoint Monitoring to start monitoring your Mule apps, you must deploy them
+to the appropriate version of Mule runtime.  Note that the Anypoint Monitoring
+images (for example, 3.9.1-AM) receive the latest patch updates once per month,
+while the non-AM (mainline) images receive patch updates as soon as they are
+available. If you require the latest patch releases, you should use the non-AM
+images.
 
 |===
 | Platform | Mule Version | Features
@@ -67,11 +72,11 @@ For Anypoint Monitoring to start monitoring your Mule apps, you must deploy them
 
 | Anypoint Platform (CloudHub)
 | 4.1.1-AM
-| Basic metrics and logs
+| Basic metrics (xref:dashboard-config-ref#metrics_basic[JVM-related only]) and logs
 
 | Anypoint Platform (CloudHub)
 | 4.1.2-AM
-| Basic metrics and logs
+| Basic metrics (xref:dashboard-config-ref#metrics_basic[JVM-related only]) and logs
 |===
 
 Note that metrics are used by graphs and other charts within xref:dashboards.adoc[Dashboards].


### PR DESCRIPTION
also adds important note about AM images in the quickstart for DOCS-3010