### PR TITLE
Update log-points.adoc

### DIFF
--- a/modules/ROOT/pages/log-points.adoc
+++ b/modules/ROOT/pages/log-points.adoc
@@ -67,11 +67,8 @@ You can monitor the following request header log points: +
 You can click the blue box to the left of *Header* to select all log points.
 Select *Body* to monitor the *Response Body*.
 . Click *Save & Apply*. +
-A message that your configuration has been applied appears at the top of the page with a *View API Logs* link.
-. Click the *View API Logs* link to view the logs for the selected log point. +
-The logs may take a moment to appear.
-+
-image::view-api-logs-link.png[]
+A message that your configuration has been applied appears at the top of the page. The logs may take a moment to appear.
+
 +
 [NOTE]
 When you are finished monitoring API log points, you should disable the log point monitoring, as it can impact your application's performance.


### PR DESCRIPTION
This is a misleading comment. The View to logs link can only be shown in the case this is an api with a proxy. Refer to slack discussion,
https://mulesoft.slack.com/archives/GAJ03HPQQ/p1562006351108200

It is better not to show this description