### PR TITLE
Update am-installing.adoc

### DIFF
--- a/modules/ROOT/pages/am-installing.adoc
+++ b/modules/ROOT/pages/am-installing.adoc
@@ -85,13 +85,13 @@ To use the SOCKS5 protocol for monitoring, you must:
 . Install the Anypoint Monitoring agent and use the `-p` option. For example, on a Windows server, at the command line, enter: 
 
 ----
-<location-of-am-folder\bin>powershell -file install.ps1 -s <server-id> -p socks5://user:password@socks5-server:1080
+<location-of-am-folder\bin>powershell -file install.ps1 -p socks5://user:password@socks5-server:1080
 ----
 
 For a Linux server, enter:
 
 ----
-$ ./install -s <server-id> -p socks5://user:password@socks5-server:1080
+$ ./install -p socks5://user:password@socks5-server:1080
 ---- 
 
 
@@ -114,10 +114,12 @@ If necessary, you can whitelist the endpoint for outbound firewall rules so your
 
 If you need to update the Anypoint Monitoring agent at some point in the future, follow these steps.
 
+. Stop Mule.
 . In the `am` folder, run the following command: +
-`./bin/uninstall script`
+`./bin/uninstall`
 . Delete the `am` folder.
-. Follow the instructions for <<install_ap_monitoring_onprem,installing the Anypoint Monitoring agent>> on-premises. 
+. Follow the instructions for <<install_ap_monitoring_onprem,installing the Anypoint Monitoring agent>> on-premises.
+. Start Mule.
 
 == Performance Impact
 


### PR DESCRIPTION
- Starting from am-2.1.5.0, the `-s` argument is not required any more for the `install` script.
- Clarifying Update the Anypoint Monitoring Agent instructions. 