### PR TITLE
Fix include statements.

### DIFF
--- a/modules/ROOT/pages/alerts-config.adoc
+++ b/modules/ROOT/pages/alerts-config.adoc
@@ -37,7 +37,7 @@ You can set up alerts to trigger email notifications when a data point you are m
 in the Alerts page in Anypoint Monitoring.
 
 //ANYPOINT MONITORING ALERTS
-include::{partialsdir}/include-alerts-config.adoc[]
+include::partial$include-alerts-config.adoc[leveloffset=+1]
 
 == Adding Alerts
 

--- a/modules/ROOT/pages/dashboard-custom-config-graph.adoc
+++ b/modules/ROOT/pages/dashboard-custom-config-graph.adoc
@@ -11,7 +11,7 @@ To open a configuration page for a graph, see xref:dashboard-custom-config.adoc[
 
 //GENERAL SETTINGS shared by singlestat and graph
 //== General
-include::{partialsdir}/include-general-config.adoc[]
+include::partial$include-general-config.adoc[leveloffset=+1]
 // END GENERAL
 
 == Axes (X-Axis and Y-Axis Settings)
@@ -102,7 +102,7 @@ A Titanium subscription is required to use this feature.
 
 In the *Alerts* tab, set up alerts that trigger when JVM memory utilization is too high.
 
-include::{partialsdir}/include-alerts-config.adoc[]
+include::partial$include-alerts-config.adoc[leveloffset=+1]
 
 //END ALERTS
 

--- a/modules/ROOT/pages/dashboard-custom-config-singlestat.adoc
+++ b/modules/ROOT/pages/dashboard-custom-config-singlestat.adoc
@@ -7,11 +7,11 @@ Anypoint Monitoring custom dashboards provide a way for you to configure singles
 
 //GENERAL SETTINGS shared by singlestat and graph
 //== General
-include::{partialsdir}/include-general-config.adoc[]
+include::partial$include-general-config.adoc[leveloffset=+1]
 
 // TIME RANGE SETTINGS shared by singlestat and table
 //==Time Range
-include::{partialsdir}/include-time-range-config.adoc[]
+include::partial$include-time-range-config.adoc[]
 
 == Options Tab
 

--- a/modules/ROOT/pages/dashboard-custom-config-table.adoc
+++ b/modules/ROOT/pages/dashboard-custom-config-table.adoc
@@ -12,11 +12,11 @@ In Anypoint Monitoring, you can configure tables for custom dashboard. In additi
 
 //GENERAL SETTINGS shared by singlestat, graph, table
 //== General
-include::{partialsdir}/include-general-config.adoc[]
+include::partial$include-general-config.adoc[leveloffset=+1]
 
 // TIME RANGE SETTINGS shared by singlestat and table
 //==Time Range
-include::{partialsdir}/include-time-range-config.adoc[]
+include::partial$include-time-range-config.adoc[]
 
 == Options (Data and Pagination Settings)
 


### PR DESCRIPTION
Articles can't have more than one title using a H1 level.
This PR adds a `leveloffset` attribute to the include statements that bring partials with H1 titles in it. 
It also fixes the include syntax from `include::{partialsdir}/` to the correct  `include::partial$`