### PR TITLE
Change "See Also" link from "v1.3" to "latest"

### DIFF
--- a/modules/ROOT/pages/monitor-applications-on-rtf.adoc
+++ b/modules/ROOT/pages/monitor-applications-on-rtf.adoc
@@ -16,4 +16,4 @@ Follow the instructions for xref:1.3@runtime-fabric::install-create-rtf-arm.adoc
 
 === See Also
 
-xref:1.3@runtime-fabric::manage-monitor-applications.adoc[Monitoring Applications Deployed to Runtime Fabric].
+xref:latest@runtime-fabric::manage-monitor-applications.adoc[Monitoring Applications Deployed to Runtime Fabric].

--- a/modules/ROOT/pages/monitor-applications-on-rtf.adoc
+++ b/modules/ROOT/pages/monitor-applications-on-rtf.adoc
@@ -16,4 +16,4 @@ Follow the instructions for xref:1.3@runtime-fabric::install-create-rtf-arm.adoc
 
 === See Also
 
-xref:latest@runtime-fabric::manage-monitor-applications.adoc[Monitoring Applications Deployed to Runtime Fabric].
+xref:runtime-fabric::manage-monitor-applications.adoc[Monitoring Applications Deployed to Runtime Fabric].


### PR DESCRIPTION
Was linking to an old version of the doc. I assume "latest" will be rendered correctly but "Preview" doesn't show me the link, so committer please confirm before merging.