### PR TITLE
Update api-analytics-dashboard.adoc

### DIFF
--- a/modules/ROOT/pages/api-analytics-dashboard.adoc
+++ b/modules/ROOT/pages/api-analytics-dashboard.adoc
@@ -13,7 +13,7 @@ By default, the enhanced metrics view is selected. To switch views, select *Swit
 Charts displaying the `Last 1 hour` label show data that has been collected during the past 60 minutes, starting with the current time.
 
 [NOTE]
-For Gold and Platinum subscriptions, Anypoint Monitoring retains API analytics metrics data for 90 days. API Manager retains API analytics metrics data for 70 days.
+For Gold and Platinum subscriptions, Anypoint Monitoring retains API analytics metrics data for 90 days. API Manager retains API analytics metrics data for 30 days.
 
 == Supported Versions of Mule Runtime Engine
 


### PR DESCRIPTION
API Manager retains the API Analytics data for up to 30 days, not for 70 days. 

Reference doc: https://docs.mulesoft.com/api-manager/2.x/viewing-api-analytics