### PR TITLE
Update app-dashboards.adoc

### DIFF
--- a/modules/ROOT/pages/app-dashboards.adoc
+++ b/modules/ROOT/pages/app-dashboards.adoc
@@ -662,6 +662,8 @@ The *Custom metrics* tab displays only if you have a Titanium subscription and s
 [[application-network]]
 == Application Network
 
+The *Application Network* tab displays only if you have a Titanium subscription.
+
 The chart on the *Application Network* tab shows the xref:visualizer::troubleshooting-visualization.adoc[Troubleshooting visualization] for the selected app, which must be started. The chart shows only direct callers and callees for the selected app. The connections are based on the selected time range, with a max of the most recent seven days.
 
 You can click *Metrics* to see statistics, such as average response time and failures, related to the app you selected. For more information about metrics in Anypoint Visualizer, see xref:visualizer::troubleshooting-visualization.adoc#choosing-your-metric[Choosing Your Metric].


### PR DESCRIPTION
The Application Network tab is available only for Titanium customers. This not documented anywhere and hence creating this PR