### PR TITLE
renamed duplicate element ID

### DIFF
--- a/modules/ROOT/pages/dashboard-custom-config.adoc
+++ b/modules/ROOT/pages/dashboard-custom-config.adoc
@@ -94,7 +94,7 @@ image::dashboard-custom-config-rows.png[Dashboard Row Configurations]
 
 Use the *Metadata* tab for high-level custom dashboard configurations to view metrics on a custom dashboard.
 
-[[dashboard_config]]
+[[dashboard_config_metadata]]
 image::dashboard-custom-metadata.png[Dashboard Metadata]
 
 [%header,cols="1,4"]


### PR DESCRIPTION
ref: https://docs.mulesoft.com/monitoring/dashboard-custom-config#dashboard_metadata

the ID dashboard_config is already used on the same page on line 53. A page shouldn't have 2 IDs with the same name, so I renamed the second one. 

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released