### PR TITLE
[W-10592565] reduce build warnings

### DIFF
--- a/modules/ROOT/pages/_partials/include-alerts-config.adoc
+++ b/modules/ROOT/pages/_partials/include-alerts-config.adoc
@@ -17,7 +17,7 @@ For guidance, see xref:dashboard-custom-config-graph.adoc#general_settings[Gener
 Note that you can also view <<state_history, state history>> and <<delete_alert, delete>> alerts.
 
 [[alert_config]]
-=== Configure an Advanced Alert
+== Configure an Advanced Alert
 
 In the *Alert Config* section, configure the condition under which an advanced alert is triggered.
 
@@ -34,7 +34,7 @@ Available severity levels:
 include::partial$include-alert-severity.adoc[leveloffset=+1]
 
 [[notifications]]
-=== Notifications
+== Notifications
 
 Configure an email notification when an advanced alert is triggered.
 
@@ -46,13 +46,13 @@ Configure an email notification when an advanced alert is triggered.
 |===
 
 [[state_history]]
-=== State History
+== State History
 
 View the last fifty state changes in this section of the UI.
 
 You can also clear the history.
 
 [[delete_alert]]
-=== Delete
+== Delete
 
 To delete an advanced alert, click *Delete* on the menu in the *Alerts* tab, and then confirm your deletion.

--- a/modules/ROOT/pages/_partials/include-general-config.adoc
+++ b/modules/ROOT/pages/_partials/include-general-config.adoc
@@ -23,7 +23,7 @@ image::config-general-common.png[Example: Basic Configuration]
 Other settings are specific to the setting mode (basic or advanced).
 
 [[mode_basic]]
-=== Basic Mode
+== Basic Mode
 
 In the *General* configuration tab, a basic query selects a single metric for a resource (a deployed application or API) in a given environment.
 
@@ -65,7 +65,7 @@ To exit the configuration and return to the dashboard, click the *X*.
 When you create an application panel using a JVM metric, the query that supports the panel uses only the worker-id for the app. When you modify the panel at a later time, the resource fields are populated with the query content. Because some apps share a worker-id, the resource that appears in the selector might appear to be a different resource from the resource you selected originally. However, all resources share the same worker, so the query has the correct information despite the selector displaying a different resource name.
 
 [[mode_advanced]]
-=== Advanced Mode
+== Advanced Mode
 
 In the *General* configuration tab, advanced settings support one or more fine-tuned queries for your chart.
 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -53,7 +53,7 @@ See xref:logs.adoc[Logs].
 
 Limits on data storage and retention are determined by your subscription level (Base or Titanium). All customers receive Anypoint Monitoring at the Base subscription level.
 
-* For Gold/Platinium subscriptions
+* For Gold/Platinum subscriptions
 ** Stores metric data in the same region as your control plane: US East (N. Virginia) or EU (Frankfurt)
 
 * For Titanium subscription


### PR DESCRIPTION
ref: [W-10592565](https://gus.lightning.force.com/a07EE00000laXx7YAE)

this PR provides a number of fixes/workarounds to reduce the number of build warnings and errors.

- reorganize headings so Antora doesn't generate warnings anymore
- fix 1 typo

validated via local build.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released