### PR TITLE
W-23515994 Rename Flex Gateway to Omni Gateway in customer-facing text

### DIFF
--- a/modules/ROOT/pages/integration-intelligence-dashboards.adoc
+++ b/modules/ROOT/pages/integration-intelligence-dashboards.adoc
@@ -28,7 +28,7 @@ For metrics in dashboards, Integration Intelligence supports Mule apps and Mule 
 * CloudHub (*CLOUDHUB*)
 * CloudHub 2.0 (*CLOUDHUB2*)
 * Runtime Fabric (*RTF*)
-* Omni Gateway (formerly Flex Gateway, *FLEX*)
+* Omni Gateway (*FLEX*)
 
 For logs in Integration Intelligence, see xref:integration-intelligence-logs.adoc#supported-deployment-types[Supported Deployment Types for Logs].
 


### PR DESCRIPTION
## Summary
Renames customer-facing mentions of "Flex Gateway" to "Omni Gateway" in Integration Intelligence documentation.

## Changes
- Removed "(formerly Flex Gateway)" parenthetical from deployment types section

## Test plan
- [ ] Review changes to ensure all customer-facing text has been updated
- [ ] Verify documentation builds successfully
- [ ] Confirm no broken links or references

🤖 Generated with [Claude Code](https://claude.com/claude-code)